### PR TITLE
Added  COMPUTE_BUFFER module to calculate buffer size

### DIFF
--- a/modules/crabs/compute_buffer/environment.yml
+++ b/modules/crabs/compute_buffer/environment.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - gawk

--- a/modules/crabs/compute_buffer/main.nf
+++ b/modules/crabs/compute_buffer/main.nf
@@ -1,0 +1,10 @@
+process CRABS_COMPUTE_BUFFER {
+
+    output:
+    env(buffersize)
+
+    script:
+    """
+    buffersize=\$(awk -F'\\t' 'length(\$11) > max { max=length(\$11) } END { print max*2 }' ${params.custom_db})
+    """
+}

--- a/modules/crabs/insilico_pcr/main.nf
+++ b/modules/crabs/insilico_pcr/main.nf
@@ -7,7 +7,7 @@ process CRABS_INSILICOPCR {
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/crabs:1.14.0--pyhdfd78af_0' :
-        'quay.io/biocontainers/crabs:1.14.0--pyhdfd78af_0' }"
+        'gregdenay/crabs:1.14.1' }"
 
     input:
     tuple val(meta), path(db)

--- a/modules/crabs/insilico_pcr/main.nf
+++ b/modules/crabs/insilico_pcr/main.nf
@@ -28,6 +28,7 @@ process CRABS_INSILICOPCR {
     --untrimmed ${prefix}_untrimmed.txt \\
     --forward ${meta.fwd} \\
     --reverse ${meta.rev} \\
+    --buffer-size ${meta.buffersize} \\
     --threads ${task.cpus}
 
     cat <<-END_VERSIONS > versions.yml

--- a/workflows/barbeque.nf
+++ b/workflows/barbeque.nf
@@ -15,6 +15,7 @@ include { STAGE_FILE as STAGE_SAMPLESHEET } from './../modules/helper/stage_file
 include { HELPER_CONSENSUS_HISTOGRAM }  from './../modules/helper/consensus_histogram'
 include { HELPER_TAXONOMIC_COVERAGE }   from './../modules/helper/taxonomic_coverage'
 include { HELPER_CONSENSUS_DISTRIBUTION } from './../modules/helper/consensus_distribution'
+include { CRABS_COMPUTE_BUFFER } from './../modules/crabs/compute_buffer'
 
 workflow BARBEQUE {
 
@@ -65,23 +66,25 @@ workflow BARBEQUE {
 
     // Copy the samplesheet to the results folder
     STAGE_SAMPLESHEET(samplesheet)
+    CRABS_COMPUTE_BUFFER()
 
     /*
      Combine each primer set with all requested databases
      [ meta, database_meta, database_path ]
     */
     INPUT_CHECK.out.primers.combine(ch_dbs).map { m,n,d ->
-        [
-            [ 
-                primer: m.primer,
-                fwd: m.fwd,
-                rev: m.rev,
-                min: m.min,
-                max: m.max,
-                db: n.id
-            ], d
-        ]
-    }.set { ch_primers_with_db }
+    [
+        [ 
+            primer: m.primer,
+            fwd: m.fwd,
+            rev: m.rev,
+            min: m.min,
+            max: m.max,
+            db: n.id
+        ], d
+    ]
+    }.combine(CRABS_COMPUTE_BUFFER.out).map 
+    { meta, db, buffersize ->[ meta + [buffersize: buffersize.toInteger()], db ]}.set { ch_primers_with_db }
 
     // perform insilico pcr, takes: [meta, database]
     CRABS_INSILICOPCR(


### PR DESCRIPTION
**Issue:**
The CRABS module requires a `--buffer-size` argument to prevent buffer overflow when processing large databases. If not provided or undersized, there is a high chance the buffer runs out. The existing solution is to manually compute `2 * awk -F'\t' '{ print length($NF) }' your_file.txt | sort -nr | head -n 1` and specify it using the `--buffer-size` argument to CRABS. This is painful when dealing with multiple databases and having to hardcode it every time.

**Fix:**
The buffer size calculation is incorporated in `modules/crabs/compute_buffer`. The process `CRABS_COMPUTE_BUFFER` calculates the value automatically at runtime from the database. The calculated value is passed through the `ch_primers_with_db` channel into `CRABS_INSILICOPCR` as `--buffer-size`, replacing the need to hardcode the value manually in `--crabs_insilicopcr_options`.